### PR TITLE
add seconds

### DIFF
--- a/lib/cron.dart
+++ b/lib/cron.dart
@@ -132,8 +132,12 @@ class _Cron implements Cron {
     if (_closed) return;
     if (_timer != null || _schedules.isEmpty) return;
     final now = DateTime.now();
-    final ms = _millisecondsPerSecond -
-        (now.millisecondsSinceEpoch % _millisecondsPerSecond);
+    final isTickMinute = _schedules.any((task) =>
+        (task.schedule.seconds?.contains(0) ?? false) &&
+        task.schedule.seconds?.length == 1);
+    final ms = (isTickMinute ? 60 : 1) * _millisecondsPerSecond -
+        (now.millisecondsSinceEpoch %
+            ((isTickMinute ? 60 : 1) * _millisecondsPerSecond));
     _timer = Timer(Duration(milliseconds: ms), _tick);
   }
 

--- a/lib/cron.dart
+++ b/lib/cron.dart
@@ -87,8 +87,10 @@ class Schedule {
   /// Parses the cron-formatted text and creates a schedule out of it.
   factory Schedule.parse(String cronFormat) {
     final p = cronFormat.split(RegExp('\\s+')).map(_parseConstraint).toList();
-    assert(p.length == 6);
-    return Schedule._(p[0], p[1], p[2], p[3], p[4], p[5]);
+    assert(p.length == 5 || p.length == 6);
+    return p.length == 5
+        ? Schedule._([0], p[0], p[1], p[2], p[3], p[4])
+        : Schedule._(p[0], p[1], p[2], p[3], p[4], p[5]);
   }
 
   Schedule._(this.seconds, this.minutes, this.hours, this.days, this.months,


### PR DESCRIPTION
When the CRON expression is a string comprising 6 fields, there is a seconds field at the beginning of the pattern.
`Cron().schedule(Schedule.parse('* * * * * *'), () async {
      print('every seconds');
    });`