### PR TITLE
feat(#47): add 'isRunning' getter to know the state of the task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.1
+
+- Add `isRunning` property to `ScheduledTask` to check if the task is running. [#53](https://github.com/agilord/cron/pull/53) by [francescovallone](https://github.com/francescovallone)
+
 ## 0.6.0
 
 - Add `toCronString` function and improve package. [#50](https://github.com/agilord/cron/pull/50) by [mbfakourii](https://github.com/mbfakourii)

--- a/lib/cron.dart
+++ b/lib/cron.dart
@@ -154,6 +154,9 @@ class Schedule {
 
 abstract class ScheduledTask {
   Schedule get schedule;
+
+  bool get running;
+
   Future cancel();
 }
 
@@ -213,6 +216,9 @@ class _ScheduledTask implements ScheduledTask {
   Future? _running;
   bool _overrun = false;
 
+  @override
+  bool get running => _running != null;
+
   /// The datetime a Task last run.
   DateTime lastTime = DateTime(0, 0, 0, 0, 0, 0, 0);
 
@@ -251,7 +257,7 @@ class _ScheduledTask implements ScheduledTask {
   }
 
   @override
-  Future cancel() async {
+  Future<void> cancel() async {
     _closed = true;
     _overrun = false;
     if (_running != null) {

--- a/lib/cron.dart
+++ b/lib/cron.dart
@@ -155,7 +155,7 @@ class Schedule {
 abstract class ScheduledTask {
   Schedule get schedule;
 
-  bool get running;
+  bool get isRunning;
 
   Future cancel();
 }
@@ -217,7 +217,7 @@ class _ScheduledTask implements ScheduledTask {
   bool _overrun = false;
 
   @override
-  bool get running => _running != null;
+  bool get isRunning => _running != null;
 
   /// The datetime a Task last run.
   DateTime lastTime = DateTime(0, 0, 0, 0, 0, 0, 0);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cron
 description: A time-based job scheduler similar to cron. Run tasks periodically at fixed times or intervals.
-version: 0.6.0
+version: 0.6.1
 repository: https://github.com/agilord/cron
 
 topics:

--- a/test/cron_test.dart
+++ b/test/cron_test.dart
@@ -57,7 +57,7 @@ void main() {
 
       async.elapse(Duration(minutes: 10));
 
-      expect(schedule.running, true);
+      expect(schedule.isRunning, true);
 
       async.elapse(Duration(seconds: 10));
 

--- a/test/cron_test.dart
+++ b/test/cron_test.dart
@@ -43,6 +43,28 @@ void main() {
     }, initialTime: DateTime(2000, 1, 1, 0, 0, 0, 0, 0));
   });
 
+  test('when a Schedule is running, then the "running" value should be [true]', () {
+    fakeAsync((async) {
+      final cron = Cron();
+
+      var count = 0;
+
+      final schedule = cron.schedule(Schedule.parse('* * * * *'), () async {
+        await Future.delayed(Duration(seconds: 10), () {
+          count++;
+        });
+      });
+
+      async.elapse(Duration(minutes: 10));
+
+      expect(schedule.running, true);
+
+      async.elapse(Duration(seconds: 10));
+
+      expect(count, 10);
+    }, initialTime: DateTime(2000, 1, 1, 0, 0, 0, 0, 0));
+  });
+
   test('should return correct cron format string.', () {
     expect(
       Schedule(hours: 13, minutes: 20, weekdays: [1, 2]).toCronString(),


### PR DESCRIPTION
This PR fixes the #47 issue. 
The ScheduleTask now has a `isRunning` boolean that will return true if the task is running. 
I also added the tests for this feature.