### PR TITLE
feat(#25): add job manager and jobs. use scheduledtask as templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.2
+
+- Add `JobManager` and `Job` making the `ScheduledTask` a template for the jobs. [#54](https://github.com/agilord/cron/pull/54) by [francescovallone](https://github.com/francescovallone)
+
 ## 0.6.1
 
 - Add `isRunning` property to `ScheduledTask` to check if the task is running. [#53](https://github.com/agilord/cron/pull/53) by [francescovallone](https://github.com/francescovallone)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ void main() {
 ```
 
 ## Cron parser
+
 You can easily create and parse [cron format](https://en.wikipedia.org/wiki/Cron):
 
 ```dart

--- a/lib/src/job.dart
+++ b/lib/src/job.dart
@@ -1,0 +1,12 @@
+class Job {
+
+  final String taskId;
+
+  final String id;
+
+  const Job({
+    required this.taskId,
+    required this.id,
+  });
+  
+}

--- a/lib/src/job_manager.dart
+++ b/lib/src/job_manager.dart
@@ -1,0 +1,30 @@
+import 'package:cron/cron.dart';
+import 'package:cron/src/job.dart';
+
+class JobManager {
+
+  final Map<String, List<Job>> _jobs = {};
+
+  JobManager();
+
+  void start(Job job, Task task) {
+    final jobs = _jobs[job.taskId];
+    if (jobs != null) {
+      jobs.add(job);
+    } else {
+      _jobs[job.taskId] = [job];
+    }
+    Future.microtask(() => task()).then((_) {
+      _jobs[job.taskId]?.removeWhere((element) => element.id == job.id);
+    }, onError: (_) => _);
+  }
+
+  bool isRunning(String taskId) {
+    return _jobs[taskId]?.isNotEmpty ?? false;
+  }
+
+  int count(String taskId) {
+    return _jobs[taskId]?.length ?? 0;
+  }
+
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cron
 description: A time-based job scheduler similar to cron. Run tasks periodically at fixed times or intervals.
-version: 0.6.1
+version: 0.6.2
 repository: https://github.com/agilord/cron
 
 topics:

--- a/test/cron_test.dart
+++ b/test/cron_test.dart
@@ -57,8 +57,7 @@ void main() {
 
       async.elapse(Duration(minutes: 10));
 
-      expect(schedule.isRunning, true);
-
+      expect(cron.isRunning(schedule.id), true);
       async.elapse(Duration(seconds: 10));
 
       expect(count, 10);


### PR DESCRIPTION
Hello, I tried to solve the problem regarding the JobManager (#25).

The current implementation uses a `JobManager` that manages the jobs for the `ScheduledTask` this means that the ScheduledTasks are now a template object, used only to group the jobs and to define if a new job should start.

This feat should also solve #49 since the JobManager, contrary to the ScheduledTask, can run more instances of the job.

Let me know if something is not clear or if I need to change something 😄 